### PR TITLE
Validation control now properly handles the removal of an invalid child

### DIFF
--- a/download/sample-tag-controls/validate/validate.js
+++ b/download/sample-tag-controls/validate/validate.js
@@ -49,11 +49,15 @@ $.views.tags({
       while (l--) {
         if (this.childValidates[l] === child) {
           this.childValidates.splice(l, 1);
+          this._checkChildren();
           break;
         }
       }
     },
     onChildValidate: function(child) {
+      this._checkChildren();
+    },
+    _checkChildren: function() {
       var groupIsValid = true,
         l = this.childValidates.length;
       while (l--) {


### PR DESCRIPTION
Currently the validation control doesn't update the `isValid` property when an invalid child is removed. This resolves the issue.
